### PR TITLE
corrected sinc pulse

### DIFF
--- a/bloch/rf_seq.py
+++ b/bloch/rf_seq.py
@@ -44,7 +44,7 @@ def sinc_pulse(timebandwidth, flip_angle, duration, dt, gamma=26747.52):
     """
     samples = int(duration / dt)
     theta = np.linspace(-timebandwidth/2, timebandwidth/2, samples+2)
-    rf = np.sinc(theta[1:-1] * sig.hann(samples))
+    rf = np.sinc(theta[1:-1]) * sig.hann(samples)
     rf = flip_angle * (rf/np.sum(rf))
     rf /= (gamma * dt)
     return rf


### PR DESCRIPTION
I think there is a bracket at a wrong position in the creation of a SINC pulse.

with:
```
import matplotlib.pyplot as plt
import numpy as np

from bloch.rf_seq import sinc_pulse

duration = 3.2e-3
dt = duration / 256
flip = np.pi / 2
tbw = 8

rf = sinc_pulse(tbw, flip, duration, dt)

plt.figure()
plt.plot(rf)
plt.show()
```

with the main branch I get the following pulse:
![sinc_before](https://user-images.githubusercontent.com/38735825/230324389-a842d685-b282-4540-adb7-6ebace139d7f.png)

I Think the Hanning window should be applied after the sinc creating, leading to that pulse shape which should be right
![sinc_after](https://user-images.githubusercontent.com/38735825/230324615-bdee21ae-a8e7-4bc5-b172-bd94df74b8ee.png)

Hope that can be merged, thanks for the Python Bloch Simulator